### PR TITLE
Setup Initial Backend API Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Habit Tracker
 
-This is a habit tracking application for logging and encouraging daily habits.
+This is a habit-tracking application for logging and encouraging daily habits.
 
 ## Structure
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -10,5 +10,5 @@ deploy-v1-get-habits: api/v1/get-habits.go
 # deploy the endpoints (ie. gateway) to access the APIs
 deploy-endpoints: api/openapi-functions.yaml
 	gcloud endpoints services deploy api/openapi-functions.yaml --project simon-duchastel-habit-tracker
-	./gcloud_build_image -s habit-tracker-5bp5c3riyq-uw.a.run.app -c 2023-08-20r0 -p simon-duchastel-habit-tracker
-	gcloud run deploy habit-tracker --image="gcr.io/simon-duchastel-habit-tracker/endpoints-runtime-serverless:2.45.0-habit-tracker-5bp5c3riyq-uw.a.run.app-2023-08-20r0" --allow-unauthenticated --platform managed --project=simon-duchastel-habit-tracker
+	CID=$(/gcloud_build_image -s habit-tracker-5bp5c3riyq-uw.a.run.app -c 2023-08-20r0 -p simon-duchastel-habit-tracker)
+	gcloud run deploy habit-tracker --image="gcr.io/simon-duchastel-habit-tracker/endpoints-runtime-serverless:2.45.0-habit-tracker-5bp5c3riyq-uw.a.run.app-$CID" --allow-unauthenticated --platform managed --project=simon-duchastel-habit-tracker

--- a/server/Makefile
+++ b/server/Makefile
@@ -4,8 +4,23 @@ deploy : deploy-functions deploy-endpoints
 # deploy each of the API functions
 deploy-functions: deploy-v1-get-habits
 
-deploy-v1-get-habits: api/v1/get-habits.go
-	gcloud functions deploy v1-get-habits --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=HelloHTTP --trigger-http --project=simon-duchastel-habit-tracker
+deploy-v1-get-whoami: api/v1/whoami-get.go
+	gcloud functions deploy v1-get-whoami --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=GetWhoAmIV1 --trigger-http --project=simon-duchastel-habit-tracker
+
+deploy-v1-get-habits-summary: api/v1/habits-summary-get.go
+	gcloud functions deploy v1-get-habits-summary --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=GetHabitsSummaryV1 --trigger-http --project=simon-duchastel-habit-tracker
+
+deploy-v1-get-habits-for-day: api/v1/habits-for-day-get.go
+	gcloud functions deploy v1-get-habits-for-day --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=GetHabitsForDayV1 --trigger-http --project=simon-duchastel-habit-tracker
+
+deploy-v1-post-habits-for-day: api/v1/habits-for-day-post.go
+	gcloud functions deploy v1-post-habits-for-day --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=PostHabitsForDayV1 --trigger-http --project=simon-duchastel-habit-tracker
+
+deploy-v1-get-goals: api/v1/goals-get.go
+	gcloud functions deploy v1-get-goals --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=GetGoalsV1 --trigger-http --project=simon-duchastel-habit-tracker
+
+deploy-v1-post-goals: api/v1/goals-post.go
+	gcloud functions deploy v1-post-goals --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=PostGoalsV1 --trigger-http --project=simon-duchastel-habit-tracker
 
 # NOTE - this doesn't currently work. It should be moved to a shell script or something, but is left here for reference
 # deploy the endpoints (ie. gateway) to access the APIs

--- a/server/Makefile
+++ b/server/Makefile
@@ -7,8 +7,9 @@ deploy-functions: deploy-v1-get-habits
 deploy-v1-get-habits: api/v1/get-habits.go
 	gcloud functions deploy v1-get-habits --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=HelloHTTP --trigger-http --project=simon-duchastel-habit-tracker
 
+# NOTE - this doesn't currently work. It should be moved to a shell script or something, but is left here for reference
 # deploy the endpoints (ie. gateway) to access the APIs
-deploy-endpoints: api/openapi-functions.yaml
-	gcloud endpoints services deploy api/openapi-functions.yaml --project simon-duchastel-habit-tracker
-	CID=$(/gcloud_build_image -s habit-tracker-5bp5c3riyq-uw.a.run.app -c 2023-08-20r0 -p simon-duchastel-habit-tracker)
-	gcloud run deploy habit-tracker --image="gcr.io/simon-duchastel-habit-tracker/endpoints-runtime-serverless:2.45.0-habit-tracker-5bp5c3riyq-uw.a.run.app-$CID" --allow-unauthenticated --platform managed --project=simon-duchastel-habit-tracker
+# deploy-endpoints: api/openapi-functions.yaml
+# 	gcloud endpoints services deploy api/openapi-functions.yaml --project simon-duchastel-habit-tracker
+# 	./gcloud_build_image -s habit-tracker-5bp5c3riyq-uw.a.run.app -c ${CID} -p simon-duchastel-habit-tracker
+# 	gcloud run deploy habit-tracker --image="gcr.io/simon-duchastel-habit-tracker/endpoints-runtime-serverless:2.45.0-habit-tracker-5bp5c3riyq-uw.a.run.app-${CID}" --allow-unauthenticated --platform managed --project=simon-duchastel-habit-tracker

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,0 +1,12 @@
+# deploy the habit-tracker server
+deploy : deploy-functions deploy-endpoints
+
+deploy-functions: deploy-v1-get-habits
+
+deploy-v1-get-habits: api/v1/get-habits.go
+	gcloud functions deploy v1-get-habits --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=HelloHTTP --trigger-http --project=simon-duchastel-habit-tracker
+
+deploy-endpoints: api/openapi-functions.yaml
+	gcloud endpoints services deploy api/openapi-functions.yaml --project simon-duchastel-habit-tracker
+	./gcloud_build_image -s habit-tracker-5bp5c3riyq-uw.a.run.app -c 2023-08-20r0 -p simon-duchastel-habit-tracker
+	gcloud run deploy habit-tracker --image="gcr.io/simon-duchastel-habit-tracker/endpoints-runtime-serverless:2.45.0-habit-tracker-5bp5c3riyq-uw.a.run.app-2023-08-20r0" --allow-unauthenticated --platform managed --project=simon-duchastel-habit-tracker

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,11 +1,13 @@
 # deploy the habit-tracker server
 deploy : deploy-functions deploy-endpoints
 
+# deploy each of the API functions
 deploy-functions: deploy-v1-get-habits
 
 deploy-v1-get-habits: api/v1/get-habits.go
 	gcloud functions deploy v1-get-habits --gen2 --runtime=go120 --region=us-west1 --source=. --entry-point=HelloHTTP --trigger-http --project=simon-duchastel-habit-tracker
 
+# deploy the endpoints (ie. gateway) to access the APIs
 deploy-endpoints: api/openapi-functions.yaml
 	gcloud endpoints services deploy api/openapi-functions.yaml --project simon-duchastel-habit-tracker
 	./gcloud_build_image -s habit-tracker-5bp5c3riyq-uw.a.run.app -c 2023-08-20r0 -p simon-duchastel-habit-tracker

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -29,10 +29,10 @@ paths:
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
-  /v1/habits/{userId}:
+  /v1/habits/{userId}/summary:
     get:
       summary: Gets how many habits the user has completed each day for up to the last 100 days.
-      operationId: getHabitsV1
+      operationId: getHabitsSummaryV1
       parameters:
         - in: path
           name: userId

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -37,8 +37,7 @@ paths:
         - in: path
           name: userId
           required: true
-          schema:
-            type: string
+          type: string
           description: The User ID of the user to lookup.
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits
@@ -66,14 +65,12 @@ paths:
         - in: path
           name: userId
           required: true
-          schema:
-            type: string
+          type: string
           description: The User ID of the user to lookup.
         - in: path
           name: day
           required: true
-          schema:
-            type: string
+          type: string
           description: The day to get the completed habits in the format "YYYY-MM-DD"
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits-for-day
@@ -100,14 +97,12 @@ paths:
         - in: path
           name: userId
           required: true
-          schema:
-            type: string
+          type: string
           description: The User ID of the user to lookup.
         - in: path
           name: day
           required: true
-          schema:
-            type: string
+          type: string
           description: The day to get the completed habits in the format "YYYY-MM-DD"
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-post-habits-for-day
@@ -132,11 +127,10 @@ paths:
       summary: Get the user's current goals.
       operationId: getGoalV1
       parameters:
-        - in: body
+        - in: path
           name: userId
           required: true
-          schema:
-            type: string
+          type: string
           description: The User ID of the user to lookup.
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-goals
@@ -161,17 +155,15 @@ paths:
       summary: Get the users's goals as they existed on a particular day.
       operationId: getGoalForDayV1
       parameters:
-        - in: body
+        - in: path
           name: userId
           required: true
-          schema:
-            type: string
+          type: string
           description: The User ID of the user to lookup.
-        - in: body
+        - in: path
           name: day
           required: true
-          schema:
-            type: string
+          type: string
           description: The day to get the goals on in the format "YYYY-MM-DD"
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-goals-for-day

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -238,19 +238,22 @@ definitions:
       completed:
         type: array
         items:
-          $ref: '#/definitions/Goal'
+          type: object
+          properties:
+            goalId:
+              type: string
+            title:
+              type: string
       uncompleted:
         type: array
         items:
-          $ref: '#/definitions/Goal'
+          type: object
+          properties:
+            goalId:
+              type: string
+            title:
+              type: string
   GoalsResponseV1:
-    type: object
-    properties:
-      goals:
-        type: array
-        items:
-          $ref: '#/definitions/Goal'
-  GoalsForDayResponseV1:
     type: object
     properties:
       goals:
@@ -269,7 +272,12 @@ definitions:
       uncompleted:
         type: array
         items:
-          $ref: '#/definitions/Goal'
+          type: object
+          properties:
+            goalId:
+              type: string
+            title:
+              type: string
   GoalsRequestV1:
     type: object
     properties:
@@ -288,8 +296,26 @@ definitions:
   Goal:
     type: object
     properties:
-      title:
-        type: string
       goalId:
         type: string
+      title:
+        type: string
+      isActive:
+        type: object
+        properties:
+          monday:
+            type: boolean
+          tuesday:
+            type: boolean
+          wednesday:
+            type: boolean
+          thursday:
+            type: boolean
+          friday:
+            type: boolean
+          saturday:
+            type: boolean
+          sunday:
+            type: boolean
+      
       

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -1,0 +1,27 @@
+swagger: '2.0'
+info:
+  title: Habit Tracker APIs
+  description: APIs for the Habit Tracker app
+  version: 1.0.0
+host: habit-tracker-5bp5c3riyq-uw.a.run.app
+schemes:
+  - https
+produces:
+  - application/json
+paths:
+  /v1/habits:
+    get:
+      summary: Get the habits for the current user.
+      operationId: hello
+      x-google-backend:
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits
+        protocol: h2
+      responses:
+        '200':
+          description: A list of habits.
+          schema:
+            type: string
+        '401':
+          description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
+          schema:
+            type: string

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -29,6 +29,7 @@ paths:
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
+            example: "Descriptive error message"
   /v1/{userId}/habits/summary:
     get:
       summary: Gets how many habits the user has completed each day for up to the last 100 days.
@@ -48,15 +49,17 @@ paths:
         '200':
           description: A list of how many habits the user has completed each day.
           schema:
-            $ref: '#/definitions/HabitsResponseV1'
+            $ref: '#/definitions/HabitsSummaryResponseV1'
         '401':
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
+            example: "Descriptive error message"
         '404':
           description: The user either does not exist or you do not have permission to view their habits.
           schema:
             type: string
+            example: "Descriptive error message"
   /v1/{userId}/habits/day/{day}:
     get:
       summary: Get the habits the user has completed on a particular day.
@@ -81,18 +84,20 @@ paths:
         '200':
           description: A list of habits.
           schema:
-            $ref: '#/definitions/HabitsResponseV1'
+            $ref: '#/definitions/HabitsForDayResponseV1'
         '401':
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
+            example: "Descriptive error message"
         '404':
           description: The user either does not exist or you do not have permission to view their habits.
           schema:
             type: string
+            example: "Descriptive error message"
     post:
       summary: Post that the user has completed a habit for a particular day.
-      operationId: postHabitForDayV1
+      operationId: postHabitsForDayV1
       parameters:
         - in: path
           name: userId
@@ -104,6 +109,11 @@ paths:
           required: true
           type: string
           description: The day to get the completed habits in the format "YYYY-MM-DD"
+        - in: body
+          name: body
+          description: The user to create.  
+          schema:
+            $ref: '#/definitions/HabitsForDayRequestV1'
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-post-habits-for-day
         protocol: h2
@@ -113,19 +123,21 @@ paths:
         '200':
           description: A list of habits.
           schema:
-            $ref: '#/definitions/HabitsResponseV1'
+            $ref: '#/definitions/HabitsForDayResponseV1'
         '401':
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
+            example: "Descriptive error message"
         '404':
           description: The user either does not exist or you does not have permission to post their habits.
           schema:
             type: string
+            example: "Descriptive error message"
   /v1/{userId}/goals:
     get:
       summary: Get the user's current goals.
-      operationId: getGoalV1
+      operationId: getGoalsV1
       parameters:
         - in: path
           name: userId
@@ -146,14 +158,50 @@ paths:
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
+            example: "Descriptive error message"
         '404':
           description: The user either does not exist or you do not have permission to view their goals.
           schema:
             type: string
+            example: "Descriptive error message"
+    post:
+      summary: Modify the user's current goals.
+      operationId: postGoalsV1
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          type: string
+          description: The User ID of the user to lookup.
+        - in: body
+          name: body
+          description: The user to create.  
+          schema:
+            $ref: '#/definitions/GoalsRequestV1'
+      x-google-backend:
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-goals
+        protocol: h2
+      security:
+        - auth0_jwt: []
+      responses:
+        '200':
+          description: A list of goals.
+          schema:
+            $ref: '#/definitions/GoalsResponseV1'
+        '401':
+          description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
+          schema:
+            type: string
+            example: "Descriptive error message"
+        '404':
+          description: The user either does not exist or you do not have permission to view their goals.
+          schema:
+            type: string
+            example: "Descriptive error message"
   /v1/{userId}/goals/day/{day}:
     get:
       summary: Get the users's goals as they existed on a particular day.
-      operationId: getGoalForDayV1
+      operationId: getGoalsForDayV1
       parameters:
         - in: path
           name: userId
@@ -174,15 +222,17 @@ paths:
         '200':
           description: A list of goals.
           schema:
-            $ref: '#/definitions/GoalsResponseV1'
+            $ref: '#/definitions/GoalsForDayResponseV1'
         '401':
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
+            example: "Descriptive error message"
         '404':
           description: The user either does not exist or you do not have permission to view their goals.
           schema:
             type: string
+            example: "Descriptive error message"
 
 # JWT config for Auth0
 securityDefinitions:
@@ -202,20 +252,66 @@ definitions:
     properties:
       identity:
         $ref: '#/definitions/Identity'
-  HabitsResponseV1:
+  HabitsSummaryResponseV1:
     type: object
     properties:
       habits:
         type: array
         items:
-          type: string
+          type: object
+          properties:
+            date:
+              type: string
+              example: "YYYY-MM-DD"
+            completed:
+              type: integer
+            uncompleted:
+              type: integer
+  HabitsForDayResponseV1:
+    type: object
+    properties:
+      completed:
+        type: array
+        items:
+          $ref: '#/definitions/Goal'
+      uncompleted:
+        type: array
+        items:
+          $ref: '#/definitions/Goal'
   GoalsResponseV1:
     type: object
     properties:
       goals:
         type: array
         items:
-          type: string
+          $ref: '#/definitions/Goal'
+  GoalsForDayResponseV1:
+    type: object
+    properties:
+      goals:
+        type: array
+        items:
+          $ref: '#/definitions/Goal'
+
+  # Requests
+  HabitsForDayRequestV1:
+    type: object
+    properties:
+      completed:
+        type: array
+        items:
+          $ref: '#/definitions/Goal'
+      uncompleted:
+        type: array
+        items:
+          $ref: '#/definitions/Goal'
+  GoalsRequestV1:
+    type: object
+    properties:
+      goals:
+        type: array
+        items:
+          $ref: '#/definitions/Goal'
 
   # Models (used in request/response types)
   Identity:
@@ -223,3 +319,12 @@ definitions:
     properties:
       userId:
         type: string
+        example: "user-id-123"
+  Goal:
+    type: object
+    properties:
+      title:
+        type: string
+      goalId:
+        type: string
+      

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -9,7 +9,7 @@ schemes:
 produces:
   - application/json
 paths:
-  /v1/habits-foo:
+  /v1/habits:
     post:
       summary: Get the habits for the current user.
       operationId: postHabitsV1
@@ -22,6 +22,8 @@ paths:
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits
         protocol: h2
+      security:
+        - auth0_jwt: []
       responses:
         '200':
           description: A list of habits.
@@ -31,3 +33,11 @@ paths:
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
+securityDefinitions:
+  auth0_jwt:
+    authorizationUrl: "https://simon-duchastel-habit-tracker.us.auth0.com/authorize"
+    flow: "implicit"
+    type: "oauth2"
+    x-google-issuer: "https://simon-duchastel-habit-tracker.us.auth0.com/"
+    x-google-jwks_uri: "https://simon-duchastel-habit-tracker.us.auth0.com/.well-known/jwks.json"
+    x-google-audiences: "https://habit-tracker-api.simon.duchastel.com"

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -41,7 +41,7 @@ paths:
           type: string
           description: The User ID of the user to lookup.
       x-google-backend:
-        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits-summary
         protocol: h2
       security:
         - auth0_jwt: []
@@ -179,7 +179,7 @@ paths:
           schema:
             $ref: '#/definitions/GoalsRequestV1'
       x-google-backend:
-        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-goals
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-post-goals
         protocol: h2
       security:
         - auth0_jwt: []
@@ -188,41 +188,6 @@ paths:
           description: A list of goals.
           schema:
             $ref: '#/definitions/GoalsResponseV1'
-        '401':
-          description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
-          schema:
-            type: string
-            example: "Descriptive error message"
-        '404':
-          description: The user either does not exist or you do not have permission to view their goals.
-          schema:
-            type: string
-            example: "Descriptive error message"
-  /v1/{userId}/goals/day/{day}:
-    get:
-      summary: Get the users's goals as they existed on a particular day.
-      operationId: getGoalsForDayV1
-      parameters:
-        - in: path
-          name: userId
-          required: true
-          type: string
-          description: The User ID of the user to lookup.
-        - in: path
-          name: day
-          required: true
-          type: string
-          description: The day to get the goals on in the format "YYYY-MM-DD"
-      x-google-backend:
-        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-goals-for-day
-        protocol: h2
-      security:
-        - auth0_jwt: []
-      responses:
-        '200':
-          description: A list of goals.
-          schema:
-            $ref: '#/definitions/GoalsForDayResponseV1'
         '401':
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -12,7 +12,7 @@ paths:
   /v1/habits:
     get:
       summary: Get the habits for the current user.
-      operationId: hello
+      operationId: getHabitsV1
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits
         protocol: h2

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -9,10 +9,16 @@ schemes:
 produces:
   - application/json
 paths:
-  /v1/habits:
-    get:
+  /v1/habits-foo:
+    post:
       summary: Get the habits for the current user.
-      operationId: getHabitsV1
+      operationId: postHabitsV1
+      parameters:
+        - in: body
+          name: Name
+          required: false
+          schema:
+            $ref: string
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits
         protocol: h2

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -29,7 +29,7 @@ paths:
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
-  /v1/habits/{userId}/summary:
+  /v1/{userId}/habits/summary:
     get:
       summary: Gets how many habits the user has completed each day for up to the last 100 days.
       operationId: getHabitsSummaryV1
@@ -57,7 +57,7 @@ paths:
           description: The user either does not exist or you do not have permission to view their habits.
           schema:
             type: string
-  /v1/habits/{userId}/day/{day}:
+  /v1/{userId}/habits/day/{day}:
     get:
       summary: Get the habits the user has completed on a particular day.
       operationId: getHabitsForDayV1
@@ -122,7 +122,7 @@ paths:
           description: The user either does not exist or you does not have permission to post their habits.
           schema:
             type: string
-  /v1/goals/{userId}:
+  /v1/{userId}/goals:
     get:
       summary: Get the user's current goals.
       operationId: getGoalV1
@@ -150,7 +150,7 @@ paths:
           description: The user either does not exist or you do not have permission to view their goals.
           schema:
             type: string
-  /v1/goal/{userId}/day/{day}:
+  /v1/{userId}/goals/day/{day}:
     get:
       summary: Get the users's goals as they existed on a particular day.
       operationId: getGoalForDayV1
@@ -222,6 +222,4 @@ definitions:
     type: object
     properties:
       userId:
-        type: array
-        items:
-          type: string
+        type: string

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -6,19 +6,40 @@ info:
 host: habit-tracker-5bp5c3riyq-uw.a.run.app
 schemes:
   - https
+consumes:
+  - application/json
 produces:
   - application/json
 paths:
-  /v1/habits:
-    post:
-      summary: Get the habits for the current user.
-      operationId: postHabitsV1
-      parameters:
-        - in: body
-          name: Name
-          required: false
+  /v1/whoami:
+    get:
+      summary: Gets the identity of the current user.
+      operationId: getWhoAmIV1
+      x-google-backend:
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-whoami
+        protocol: h2
+      security:
+        - auth0_jwt: []
+      responses:
+        '200':
+          description: The identity of the currently signed-in user.
           schema:
-            $ref: string
+            $ref: '#/definitions/WhoAmIResponseV1'
+        '401':
+          description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
+          schema:
+            type: string
+  /v1/habits/{userId}:
+    get:
+      summary: Gets how many habits the user has completed each day for up to the last 100 days.
+      operationId: getHabitsV1
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+          description: The User ID of the user to lookup.
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits
         protocol: h2
@@ -26,13 +47,152 @@ paths:
         - auth0_jwt: []
       responses:
         '200':
-          description: A list of habits.
+          description: A list of how many habits the user has completed each day.
           schema:
-            type: string
+            $ref: '#/definitions/HabitsResponseV1'
         '401':
           description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
           schema:
             type: string
+        '404':
+          description: The user either does not exist or you do not have permission to view their habits.
+          schema:
+            type: string
+  /v1/habits/{userId}/day/{day}:
+    get:
+      summary: Get the habits the user has completed on a particular day.
+      operationId: getHabitsForDayV1
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+          description: The User ID of the user to lookup.
+        - in: path
+          name: day
+          required: true
+          schema:
+            type: string
+          description: The day to get the completed habits in the format "YYYY-MM-DD"
+      x-google-backend:
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits-for-day
+        protocol: h2
+      security:
+        - auth0_jwt: []
+      responses:
+        '200':
+          description: A list of habits.
+          schema:
+            $ref: '#/definitions/HabitsResponseV1'
+        '401':
+          description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
+          schema:
+            type: string
+        '404':
+          description: The user either does not exist or you do not have permission to view their habits.
+          schema:
+            type: string
+    post:
+      summary: Post that the user has completed a habit for a particular day.
+      operationId: postHabitForDayV1
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+          description: The User ID of the user to lookup.
+        - in: path
+          name: day
+          required: true
+          schema:
+            type: string
+          description: The day to get the completed habits in the format "YYYY-MM-DD"
+      x-google-backend:
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-post-habits-for-day
+        protocol: h2
+      security:
+        - auth0_jwt: []
+      responses:
+        '200':
+          description: A list of habits.
+          schema:
+            $ref: '#/definitions/HabitsResponseV1'
+        '401':
+          description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
+          schema:
+            type: string
+        '404':
+          description: The user either does not exist or you does not have permission to post their habits.
+          schema:
+            type: string
+  /v1/goals/{userId}:
+    get:
+      summary: Get the user's current goals.
+      operationId: getGoalV1
+      parameters:
+        - in: body
+          name: userId
+          required: true
+          schema:
+            type: string
+          description: The User ID of the user to lookup.
+      x-google-backend:
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-goals
+        protocol: h2
+      security:
+        - auth0_jwt: []
+      responses:
+        '200':
+          description: A list of goals.
+          schema:
+            $ref: '#/definitions/GoalsResponseV1'
+        '401':
+          description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
+          schema:
+            type: string
+        '404':
+          description: The user either does not exist or you do not have permission to view their goals.
+          schema:
+            type: string
+  /v1/goal/{userId}/day/{day}:
+    get:
+      summary: Get the users's goals as they existed on a particular day.
+      operationId: getGoalForDayV1
+      parameters:
+        - in: body
+          name: userId
+          required: true
+          schema:
+            type: string
+          description: The User ID of the user to lookup.
+        - in: body
+          name: day
+          required: true
+          schema:
+            type: string
+          description: The day to get the goals on in the format "YYYY-MM-DD"
+      x-google-backend:
+        address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-goals-for-day
+        protocol: h2
+      security:
+        - auth0_jwt: []
+      responses:
+        '200':
+          description: A list of goals.
+          schema:
+            $ref: '#/definitions/GoalsResponseV1'
+        '401':
+          description: The user is not authenticated and cannot make this request (the user should authenticate before retrying). 
+          schema:
+            type: string
+        '404':
+          description: The user either does not exist or you do not have permission to view their goals.
+          schema:
+            type: string
+
+# JWT config for Auth0
 securityDefinitions:
   auth0_jwt:
     authorizationUrl: "https://simon-duchastel-habit-tracker.us.auth0.com/authorize"
@@ -41,3 +201,35 @@ securityDefinitions:
     x-google-issuer: "https://simon-duchastel-habit-tracker.us.auth0.com/"
     x-google-jwks_uri: "https://simon-duchastel-habit-tracker.us.auth0.com/.well-known/jwks.json"
     x-google-audiences: "https://habit-tracker-api.simon.duchastel.com"
+
+# Schema for request/response types
+definitions:
+  # Responses
+  WhoAmIResponseV1:
+    type: object
+    properties:
+      identity:
+        $ref: '#/definitions/Identity'
+  HabitsResponseV1:
+    type: object
+    properties:
+      habits:
+        type: array
+        items:
+          type: string
+  GoalsResponseV1:
+    type: object
+    properties:
+      goals:
+        type: array
+        items:
+          type: string
+
+  # Models (used in request/response types)
+  Identity:
+    type: object
+    properties:
+      userId:
+        type: array
+        items:
+          type: string

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -268,15 +268,16 @@ definitions:
       completed:
         type: array
         items:
-          $ref: '#/definitions/Goal'
+          type: object
+          properties:
+            goalId:
+              type: string
       uncompleted:
         type: array
         items:
           type: object
           properties:
             goalId:
-              type: string
-            title:
               type: string
   GoalsRequestV1:
     type: object

--- a/server/api/v1/get-habits.go
+++ b/server/api/v1/get-habits.go
@@ -9,7 +9,7 @@ import (
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 )
 
-func init() {
+func InitGetHabits() {
 	functions.HTTP("HelloHTTP", HelloHTTP)
 }
 

--- a/server/api/v1/goals-get.go
+++ b/server/api/v1/goals-get.go
@@ -3,10 +3,11 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"html"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+
+	"github.com/simon-duchastel/habit-tracker/server/models"
 )
 
 func InitGetGoals() {
@@ -14,16 +15,55 @@ func InitGetGoals() {
 }
 
 func GetGoals(w http.ResponseWriter, r *http.Request) {
-	var d struct {
-		Name string `json:"name"`
+	response := models.GoalsResponseV1{}
+	response.Goals = []models.Goal{
+		{
+			GoalId: "goal-123",
+			Title:  "Clean room",
+			IsActive: models.DaysActive{
+				Monday:    false,
+				Tuesday:   false,
+				Wednesday: false,
+				Thursday:  false,
+				Friday:    false,
+				Saturday:  true,
+				Sunday:    true,
+			},
+		},
+		{
+			GoalId: "goal-456",
+			Title:  "Run 3 miles",
+			IsActive: models.DaysActive{
+				Monday:    true,
+				Tuesday:   false,
+				Wednesday: true,
+				Thursday:  false,
+				Friday:    true,
+				Saturday:  true,
+				Sunday:    false,
+			},
+		},
+		{
+			GoalId: "goal-789",
+			Title:  "Wash 3 dishes",
+			IsActive: models.DaysActive{
+				Monday:    true,
+				Tuesday:   true,
+				Wednesday: true,
+				Thursday:  true,
+				Friday:    true,
+				Saturday:  true,
+				Sunday:    true,
+			},
+		},
 	}
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
-		fmt.Fprint(w, "Hello, World!")
+	data, err := json.Marshal(&response)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error writing json response")
 		return
 	}
-	if d.Name == "" {
-		fmt.Fprint(w, "Hello, World!")
-		return
-	}
-	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
 }

--- a/server/api/v1/goals-get.go
+++ b/server/api/v1/goals-get.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+func InitGetGoals() {
+	functions.HTTP("GetGoals", GetGoals)
+}
+
+func GetGoals(w http.ResponseWriter, r *http.Request) {
+	var d struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	if d.Name == "" {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+}

--- a/server/api/v1/goals-post.go
+++ b/server/api/v1/goals-post.go
@@ -3,10 +3,11 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"html"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+
+	"github.com/simon-duchastel/habit-tracker/server/models"
 )
 
 func InitPostGoals() {
@@ -14,16 +15,63 @@ func InitPostGoals() {
 }
 
 func PostGoals(w http.ResponseWriter, r *http.Request) {
-	var d struct {
-		Name string `json:"name"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
-		fmt.Fprint(w, "Hello, World!")
+	var request models.GoalsRequestV1
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Request body does not match expected schema")
 		return
 	}
-	if d.Name == "" {
-		fmt.Fprint(w, "Hello, World!")
+
+	response := models.GoalsResponseV1{}
+	response.Goals = []models.Goal{
+		{
+			GoalId: "goal-123",
+			Title:  "Clean room",
+			IsActive: models.DaysActive{
+				Monday:    false,
+				Tuesday:   false,
+				Wednesday: false,
+				Thursday:  false,
+				Friday:    false,
+				Saturday:  true,
+				Sunday:    true,
+			},
+		},
+		{
+			GoalId: "goal-456",
+			Title:  "Run 3 miles",
+			IsActive: models.DaysActive{
+				Monday:    true,
+				Tuesday:   false,
+				Wednesday: true,
+				Thursday:  false,
+				Friday:    true,
+				Saturday:  true,
+				Sunday:    false,
+			},
+		},
+		{
+			GoalId: "goal-789",
+			Title:  "Wash 3 dishes",
+			IsActive: models.DaysActive{
+				Monday:    true,
+				Tuesday:   true,
+				Wednesday: true,
+				Thursday:  true,
+				Friday:    true,
+				Saturday:  true,
+				Sunday:    true,
+			},
+		},
+	}
+	data, err := json.Marshal(&response)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error writing json response")
 		return
 	}
-	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
 }

--- a/server/api/v1/goals-post.go
+++ b/server/api/v1/goals-post.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+func InitPostGoals() {
+	functions.HTTP("PostGoals", PostGoals)
+}
+
+func PostGoals(w http.ResponseWriter, r *http.Request) {
+	var d struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	if d.Name == "" {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+}

--- a/server/api/v1/habits-for-day-get.go
+++ b/server/api/v1/habits-for-day-get.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+func InitGetHabitsForDay() {
+	functions.HTTP("GetHabitsForDay", GetHabitsForDay)
+}
+
+func GetHabitsForDay(w http.ResponseWriter, r *http.Request) {
+	var d struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	if d.Name == "" {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+}

--- a/server/api/v1/habits-for-day-get.go
+++ b/server/api/v1/habits-for-day-get.go
@@ -3,10 +3,11 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"html"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+
+	"github.com/simon-duchastel/habit-tracker/server/models"
 )
 
 func InitGetHabitsForDay() {
@@ -14,16 +15,31 @@ func InitGetHabitsForDay() {
 }
 
 func GetHabitsForDay(w http.ResponseWriter, r *http.Request) {
-	var d struct {
-		Name string `json:"name"`
+	response := models.HabitsForDayResponseV1{}
+	response.Completed = []models.GoalSummary{
+		{
+			GoalId: "goal-123",
+			Title:  "Clean room",
+		},
+		{
+			GoalId: "goal-456",
+			Title:  "Run 3 miles",
+		},
 	}
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
-		fmt.Fprint(w, "Hello, World!")
+	response.Uncompleted = []models.GoalSummary{
+		{
+			GoalId: "goal-789",
+			Title:  "Wash 3 dishes",
+		},
+	}
+
+	data, err := json.Marshal(&response)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error writing json response")
 		return
 	}
-	if d.Name == "" {
-		fmt.Fprint(w, "Hello, World!")
-		return
-	}
-	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
 }

--- a/server/api/v1/habits-for-day-post.go
+++ b/server/api/v1/habits-for-day-post.go
@@ -3,10 +3,11 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"html"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+
+	"github.com/simon-duchastel/habit-tracker/server/models"
 )
 
 func InitPostHabitsForDay() {
@@ -14,16 +15,39 @@ func InitPostHabitsForDay() {
 }
 
 func PostHabitsForDay(w http.ResponseWriter, r *http.Request) {
-	var d struct {
-		Name string `json:"name"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
-		fmt.Fprint(w, "Hello, World!")
+	var request models.HabitsForDayRequestV1
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Request body does not match expected schema")
 		return
 	}
-	if d.Name == "" {
-		fmt.Fprint(w, "Hello, World!")
+
+	response := models.HabitsForDayResponseV1{}
+	response.Completed = []models.GoalSummary{
+		{
+			GoalId: "goal-123",
+			Title:  "Clean room",
+		},
+		{
+			GoalId: "goal-456",
+			Title:  "Run 3 miles",
+		},
+	}
+	response.Uncompleted = []models.GoalSummary{
+		{
+			GoalId: "goal-789",
+			Title:  "Wash 3 dishes",
+		},
+	}
+
+	data, err := json.Marshal(&response)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error writing json response")
 		return
 	}
-	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
 }

--- a/server/api/v1/habits-for-day-post.go
+++ b/server/api/v1/habits-for-day-post.go
@@ -9,12 +9,11 @@ import (
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 )
 
-func InitGetHabits() {
-	functions.HTTP("HelloHTTP", HelloHTTP)
+func InitPostHabitsForDay() {
+	functions.HTTP("PostHabitsForDay", PostHabitsForDay)
 }
 
-// HelloHTTP is an HTTP Cloud Function with a request parameter.
-func HelloHTTP(w http.ResponseWriter, r *http.Request) {
+func PostHabitsForDay(w http.ResponseWriter, r *http.Request) {
 	var d struct {
 		Name string `json:"name"`
 	}

--- a/server/api/v1/habits-summary-get.go
+++ b/server/api/v1/habits-summary-get.go
@@ -3,10 +3,11 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"html"
 	"net/http"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+
+	"github.com/simon-duchastel/habit-tracker/server/models"
 )
 
 func InitGetHabitsSummary() {
@@ -14,16 +15,37 @@ func InitGetHabitsSummary() {
 }
 
 func GetHabitsSummary(w http.ResponseWriter, r *http.Request) {
-	var d struct {
-		Name string `json:"name"`
+	response := models.HabitsSummaryResponseV1{}
+	response.Habits = []models.HabitSummary{
+		{
+			Date:        "2023-08-26",
+			Completed:   2,
+			Uncompleted: 3,
+		},
+		{
+			Date:        "2023-08-25",
+			Completed:   3,
+			Uncompleted: 3,
+		},
+		{
+			Date:        "2023-08-25",
+			Completed:   3,
+			Uncompleted: 3,
+		},
+		{
+			Date:        "2023-08-25",
+			Completed:   3,
+			Uncompleted: 3,
+		},
 	}
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
-		fmt.Fprint(w, "Hello, World!")
+
+	data, err := json.Marshal(&response)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error writing json response")
 		return
 	}
-	if d.Name == "" {
-		fmt.Fprint(w, "Hello, World!")
-		return
-	}
-	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
 }

--- a/server/api/v1/habits-summary-get.go
+++ b/server/api/v1/habits-summary-get.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+func InitGetHabitsSummary() {
+	functions.HTTP("GetHabitsSummary", GetHabitsSummary)
+}
+
+func GetHabitsSummary(w http.ResponseWriter, r *http.Request) {
+	var d struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	if d.Name == "" {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+}

--- a/server/api/v1/whoami-get.go
+++ b/server/api/v1/whoami-get.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+)
+
+func InitGetWhoAmI() {
+	functions.HTTP("GetWhoAmI", GetWhoAmI)
+}
+
+func GetWhoAmI(w http.ResponseWriter, r *http.Request) {
+	var d struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	if d.Name == "" {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+}

--- a/server/api/v1/whoami-get.go
+++ b/server/api/v1/whoami-get.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/simon-duchastel/habit-tracker/server/models"
-	_ "github.com/simon-duchastel/habit-tracker/server/models"
-
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+
+	"github.com/simon-duchastel/habit-tracker/server/models"
 )
 
 func InitGetWhoAmI() {

--- a/server/api/v1/whoami-get.go
+++ b/server/api/v1/whoami-get.go
@@ -3,8 +3,10 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"html"
 	"net/http"
+
+	"github.com/simon-duchastel/habit-tracker/server/models"
+	_ "github.com/simon-duchastel/habit-tracker/server/models"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 )
@@ -14,16 +16,16 @@ func InitGetWhoAmI() {
 }
 
 func GetWhoAmI(w http.ResponseWriter, r *http.Request) {
-	var d struct {
-		Name string `json:"name"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
-		fmt.Fprint(w, "Hello, World!")
+	response := models.WhoAmIResponseV1{}
+	response.Identity.UserId = "user-123"
+
+	data, err := json.Marshal(&response)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error writing json response")
 		return
 	}
-	if d.Name == "" {
-		fmt.Fprint(w, "Hello, World!")
-		return
-	}
-	fmt.Fprintf(w, "Hello, %s!", html.EscapeString(d.Name))
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
 }

--- a/server/functions.go
+++ b/server/functions.go
@@ -8,6 +8,26 @@ import (
 
 // Proxy functions to allow Function deployments (functions must be callable from root)
 
-func HelloHTTP(w http.ResponseWriter, r *http.Request) {
-	v1.HelloHTTP(w, r)
+func GetWhoAmIV1(w http.ResponseWriter, r *http.Request) {
+	v1.GetWhoAmI(w, r)
+}
+
+func GetHabitsSummaryV1(w http.ResponseWriter, r *http.Request) {
+	v1.GetHabitsSummary(w, r)
+}
+
+func GetHabitsForDayV1(w http.ResponseWriter, r *http.Request) {
+	v1.GetHabitsForDay(w, r)
+}
+
+func PostHabitsForDayV1(w http.ResponseWriter, r *http.Request) {
+	v1.PostHabitsForDay(w, r)
+}
+
+func GetGoalsV1(w http.ResponseWriter, r *http.Request) {
+	v1.GetGoals(w, r)
+}
+
+func PostGoalsV1(w http.ResponseWriter, r *http.Request) {
+	v1.PostGoals(w, r)
 }

--- a/server/functions.go
+++ b/server/functions.go
@@ -1,0 +1,13 @@
+package server
+
+import (
+	"net/http"
+
+	v1 "github.com/simon-duchastel/habit-tracker/server/api/v1"
+)
+
+// Proxy functions to allow Function deployments (functions must be callable from root)
+
+func HelloHTTP(w http.ResponseWriter, r *http.Request) {
+	v1.HelloHTTP(w, r)
+}

--- a/server/gcloud_build_image
+++ b/server/gcloud_build_image
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+
+# This script will download the service config and build it into
+# serverless docker image to be used for Cloud Run.
+#
+# gcloud SDK has to be installed and configured with:
+#   gcloud config set project ${PROJECT}
+#   gcloud auth login
+#
+# Following gcloud commands can be used to find out service name
+#   gcloud endpoints services list
+#   gcloud endpoints configs list --service=${SERVICE}
+# Use the latest one for the CONFIG_ID
+#
+# The script will use the latest ESPv2 version by default.
+# Use the -v option to pass in a custom version (example: -v 2.9).
+
+# Fail on any error.
+set -eo pipefail
+
+# Default to the latest released ESPv2 version.
+BASE_IMAGE_NAME="gcr.io/endpoints-release/endpoints-runtime-serverless"
+ESP_TAG="2"
+ZONE=""
+
+function error_exit() {
+  # ${BASH_SOURCE[1]} is the file name of the caller.
+  echo "${BASH_SOURCE[1]}: line ${BASH_LINENO[0]}: ${1:-Unknown Error.} (exit ${2:-1})" 1>&2
+  exit ${2:-1}
+}
+
+# To support Google Artifact Registry (GAR), the flag -g can be used to set
+# IMAGE_REPOSITORY as following:
+#   'LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY'
+
+while getopts :c:s:p:v:z:g:i: arg; do
+  case ${arg} in
+    c) CONFIG_ID="${OPTARG}";;
+    s) SERVICE="${OPTARG}";;
+    p) PROJECT="${OPTARG}";;
+    v) ESP_TAG="${OPTARG}";;
+    z) ZONE="${OPTARG}";;
+    g) IMAGE_REPOSITORY="${OPTARG}";;
+    i)
+      BASE_IMAGE="${OPTARG}"
+      ESP_FULL_VERSION="custom"
+      ;;
+    \?) error_exit "Unrecognized argument -${OPTARG}";;
+  esac
+done
+
+[[ -n "${PROJECT}" ]] || error_exit "Missing required PROJECT"
+[[ -n "${SERVICE}" ]] || error_exit "Missing required SERVICE"
+[[ -n "${CONFIG_ID}" ]] || error_exit "Missing required CONFIG_ID"
+
+# If user did not pass in custom image, then form the fully-qualified base image.
+if [ -z "${BASE_IMAGE}" ]; then
+  BASE_IMAGE="${BASE_IMAGE_NAME}:${ESP_TAG}"
+fi;
+echo "Using base image: ${BASE_IMAGE}"
+
+# If IMAGE_REPOSITORY is not set, it is to support container registry format:
+#   'gcr.io/PROJECT-ID' or 'us.gcr.io/PROJECT-ID'
+if [ -z "${IMAGE_REPOSITORY}" ]; then
+  IMAGE_REPOSITORY="gcr.io/${PROJECT}"
+  if [ -n "${ZONE}" ]; then
+    IMAGE_REPOSITORY="${ZONE}.${IMAGE_REPOSITORY}"
+  fi
+fi
+
+# If user did not pass in a custom image, then determine the ESP version.
+if [ -z "${ESP_FULL_VERSION}" ]; then
+  echo "Determining fully-qualified ESP version for tag: ${ESP_TAG}"
+
+  ALL_TAGS=$(gcloud container images list-tags "${BASE_IMAGE_NAME}" \
+      --filter="tags~^${ESP_TAG}$" \
+      --format="value(tags)")
+  IFS=',' read -ra TAGS_ARRAY <<< "${ALL_TAGS}"
+
+  if [ ${#TAGS_ARRAY[@]} -eq 0 ]; then
+    error_exit "Did not find ESP version: ${ESP_TAG}"
+  fi;
+
+  # Find the tag with the longest length.
+  ESP_FULL_VERSION=""
+  for tag in "${TAGS_ARRAY[@]}"; do
+     if [ ${#tag} -gt ${#ESP_FULL_VERSION} ]; then
+        ESP_FULL_VERSION=${tag}
+     fi
+  done
+fi
+echo "Building image for ESP version: ${ESP_FULL_VERSION}"
+
+tempdir="$(mktemp -d /tmp/docker.XXXX)"
+cd "${tempdir}"
+
+# Be careful about exposing the access token.
+access_token="$(gcloud auth print-access-token)"
+curl --fail -o "service.json" -H @- \
+  "https://servicemanagement.googleapis.com/v1/services/${SERVICE}/configs/${CONFIG_ID}?view=FULL" <<EOF || error_exit "Failed to download service config"
+Authorization: Bearer ${access_token}
+EOF
+
+(
+set -x
+
+cat <<EOF > Dockerfile
+FROM ${BASE_IMAGE}
+
+USER root
+ENV ENDPOINTS_SERVICE_PATH /etc/endpoints/service.json
+COPY service.json \${ENDPOINTS_SERVICE_PATH}
+RUN chown -R envoy:envoy \${ENDPOINTS_SERVICE_PATH} && chmod -R 755 \${ENDPOINTS_SERVICE_PATH}
+USER envoy
+
+ENTRYPOINT ["/env_start_proxy.py"]
+EOF
+
+NEW_IMAGE="${IMAGE_REPOSITORY}/endpoints-runtime-serverless:${ESP_FULL_VERSION}-${SERVICE}-${CONFIG_ID}"
+gcloud builds submit --tag "${NEW_IMAGE}" . --project="${PROJECT}"
+)
+
+# Delete the temporary directory we created earlier.
+# Move back to the previous directory with an echo.
+rm -r "${PWD}"
+cd ~-

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,11 +1,10 @@
-module habit-tracker-server
+module github.com/simon-duchastel/habit-tracker/server
 
 go 1.20
 
 require github.com/GoogleCloudPlatform/functions-framework-go v1.7.4
 
 require (
-	cloud.google.com/go/functions v1.13.0 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.14.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -35,7 +35,6 @@ cloud.google.com/go v0.102.1/go.mod h1:XZ77E9qnTEnrgEOvr4xzfdX5TRo7fB4T2F4O6+34h
 cloud.google.com/go v0.104.0/go.mod h1:OO6xxXdJyvuJPcEPBLN9BJPD+jep5G1+2U5B5gkRYtA=
 cloud.google.com/go v0.105.0/go.mod h1:PrLgOJNe5nfE9UMxKxgXj4mD3voiP+YQ6gdt6KMFOKM=
 cloud.google.com/go v0.107.0/go.mod h1:wpc2eNrD7hXUTy8EKS10jkxpZBjASrORK7goS+3YX2I=
-cloud.google.com/go v0.110.0 h1:Zc8gqp3+a9/Eyph2KDmcGaPtbKRIoqq4YTlL4NMD0Ys=
 cloud.google.com/go v0.110.0/go.mod h1:SJnCLqQ0FCFGSZMUNUf84MV3Aia54kn7pi8st7tMzaY=
 cloud.google.com/go/accessapproval v1.4.0/go.mod h1:zybIuC3KpDOvotz59lFe5qxRZx6C75OtwbisN56xYB4=
 cloud.google.com/go/accessapproval v1.5.0/go.mod h1:HFy3tuiGvMdcd/u+Cu5b9NkO1pEICJ46IR82PoUdplw=
@@ -270,7 +269,6 @@ cloud.google.com/go/functions v1.8.0/go.mod h1:RTZ4/HsQjIqIYP9a9YPbU+QFoQsAlYgrw
 cloud.google.com/go/functions v1.9.0/go.mod h1:Y+Dz8yGguzO3PpIjhLTbnqV1CWmgQ5UwtlpzoyquQ08=
 cloud.google.com/go/functions v1.10.0/go.mod h1:0D3hEOe3DbEvCXtYOZHQZmD+SzYsi1YbI7dGvHfldXw=
 cloud.google.com/go/functions v1.12.0/go.mod h1:AXWGrF3e2C/5ehvwYo/GH6O5s09tOPksiKhz+hH8WkA=
-cloud.google.com/go/functions v1.13.0 h1:pPDqtsXG2g9HeOQLoquLbmvmb82Y4Ezdo1GXuotFoWg=
 cloud.google.com/go/functions v1.13.0/go.mod h1:EU4O007sQm6Ef/PwRsI8N2umygGqPBS/IZQKBQBcJ3c=
 cloud.google.com/go/gaming v1.5.0/go.mod h1:ol7rGcxP/qHTRQE/RO4bxkXq+Fix0j6D4LFPzYTIrDM=
 cloud.google.com/go/gaming v1.6.0/go.mod h1:YMU1GEvA39Qt3zWGyAVA9bpYz/yAhTvaQ1t2sK4KPUA=

--- a/server/models/api-requests.go
+++ b/server/models/api-requests.go
@@ -1,10 +1,10 @@
 package models
 
 type HabitsForDayRequestV1 struct {
-	completed   []Goal
-	uncompleted []Goal
+	Completed   []Goal `json:"completed"`
+	Uncompleted []Goal `json:"Uncompleted"`
 }
 
 type GoalsRequestV1 struct {
-	goal []Goal
+	Goal []Goal `json:"goal"`
 }

--- a/server/models/api-requests.go
+++ b/server/models/api-requests.go
@@ -2,7 +2,7 @@ package models
 
 type HabitsForDayRequestV1 struct {
 	Completed   []Goal `json:"completed"`
-	Uncompleted []Goal `json:"Uncompleted"`
+	Uncompleted []Goal `json:"uncompleted"`
 }
 
 type GoalsRequestV1 struct {

--- a/server/models/api-requests.go
+++ b/server/models/api-requests.go
@@ -1,0 +1,10 @@
+package models
+
+type HabitsForDayRequestV1 struct {
+	completed   []Goal
+	uncompleted []Goal
+}
+
+type GoalsRequestV1 struct {
+	goal []Goal
+}

--- a/server/models/api-requests.go
+++ b/server/models/api-requests.go
@@ -1,8 +1,8 @@
 package models
 
 type HabitsForDayRequestV1 struct {
-	Completed   []Goal `json:"completed"`
-	Uncompleted []Goal `json:"uncompleted"`
+	Completed   []GoalId `json:"completed"`
+	Uncompleted []GoalId `json:"uncompleted"`
 }
 
 type GoalsRequestV1 struct {

--- a/server/models/api-requests_test.go
+++ b/server/models/api-requests_test.go
@@ -10,21 +10,17 @@ func TestHabitsForDayRequestV1(t *testing.T) {
 	requestJson := []byte(`{
 		"completed": [
 			{
-				"title": "complete-goal",
 				"goalId": "goal-12"
 			},
 			{
-				"title": "second-complete-goal",
 				"goalId": "goal-34"
 			}
 		],
 		"uncompleted": [
 			{
-				"title": "incomplete-goal",
 				"goalId": "goal-56"
 			},
 			{
-				"title": "second-incomplete-goal",
 				"goalId": "goal-78"
 			}
 		]
@@ -36,23 +32,19 @@ func TestHabitsForDayRequestV1(t *testing.T) {
 		t.Fatalf("Failed to parse json")
 	}
 	expectedRequest := HabitsForDayRequestV1{
-		Completed: []Goal{
+		Completed: []GoalId{
 			{
-				Title:  "complete-goal",
 				GoalId: "goal-12",
 			},
 			{
-				Title:  "second-complete-goal",
 				GoalId: "goal-34",
 			},
 		},
-		Uncompleted: []Goal{
+		Uncompleted: []GoalId{
 			{
-				Title:  "incomplete-goal",
 				GoalId: "goal-56",
 			},
 			{
-				Title:  "second-incomplete-goal",
 				GoalId: "goal-78",
 			},
 		},

--- a/server/models/api-requests_test.go
+++ b/server/models/api-requests_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestHabitsForDayRequestV1(t *testing.T) {
-	var requestJson = []byte(`{
+	requestJson := []byte(`{
 		"completed": [
 			{
 				"title": "complete-goal",
@@ -15,7 +15,7 @@ func TestHabitsForDayRequestV1(t *testing.T) {
 			},
 			{
 				"title": "second-complete-goal",
-				goalId": "goal-34"
+				"goalId": "goal-34"
 			}
 		],
 		"uncompleted": [

--- a/server/models/api-requests_test.go
+++ b/server/models/api-requests_test.go
@@ -1,0 +1,64 @@
+package models
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestHabitsForDayRequestV1(t *testing.T) {
+	var requestJson = []byte(`{
+		"completed": [
+			{
+				"title": "complete-goal",
+				"goalId": "goal-12"
+			},
+			{
+				"title": "second-complete-goal",
+				goalId": "goal-34"
+			}
+		],
+		"uncompleted": [
+			{
+				"title": "incomplete-goal",
+				"goalId": "goal-56"
+			},
+			{
+				"title": "second-incomplete-goal",
+				"goalId": "goal-78"
+			}
+		]
+	}`)
+
+	var request HabitsForDayRequestV1
+	err := json.Unmarshal(requestJson, &request)
+	if err != nil {
+		t.Fatalf("Failed to parse json")
+	}
+	expectedRequest := HabitsForDayRequestV1{
+		Completed: []Goal{
+			{
+				Title:  "complete-goal",
+				GoalId: "goal-12",
+			},
+			{
+				Title:  "second-complete-goal",
+				GoalId: "goal-34",
+			},
+		},
+		Uncompleted: []Goal{
+			{
+				Title:  "incomplete-goal",
+				GoalId: "goal-56",
+			},
+			{
+				Title:  "second-incomplete-goal",
+				GoalId: "goal-78",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(request, expectedRequest) {
+		t.Fatalf("Request did not match expected value:\n\texpected \"%v\"\n\tgot      \"%v\"", expectedRequest, request)
+	}
+}

--- a/server/models/api-responses.go
+++ b/server/models/api-responses.go
@@ -16,7 +16,3 @@ type HabitsForDayResponseV1 struct {
 type GoalsResponseV1 struct {
 	Goals []Goal `json:"goals"`
 }
-
-type GoalsForDayResponseV1 struct {
-	Goals []Goal `json:"goals"`
-}

--- a/server/models/api-responses.go
+++ b/server/models/api-responses.go
@@ -1,22 +1,22 @@
 package models
 
 type WhoAmIResponseV1 struct {
-	identity Identity
+	Identity Identity `json:"identity"`
 }
 
 type HabitsSummaryResponseV1 struct {
-	habits []HabitSummary
+	Habits []HabitSummary `json:"habits"`
 }
 
 type HabitsForDayResponseV1 struct {
-	completed   []Goal
-	uncompleted []Goal
+	Completed   []Goal `json:"completed"`
+	Uncompleted []Goal `json:"uncompleted"`
 }
 
 type GoalsResponseV1 struct {
-	goals []Goal
+	Goals []Goal `json:"goals"`
 }
 
 type GoalsForDayResponseV1 struct {
-	goals []Goal
+	Goals []Goal `json:"goals"`
 }

--- a/server/models/api-responses.go
+++ b/server/models/api-responses.go
@@ -1,0 +1,22 @@
+package models
+
+type WhoAmIResponseV1 struct {
+	identity Identity
+}
+
+type HabitsSummaryResponseV1 struct {
+	habits []HabitSummary
+}
+
+type HabitsForDayResponseV1 struct {
+	completed   []Goal
+	uncompleted []Goal
+}
+
+type GoalsResponseV1 struct {
+	goals []Goal
+}
+
+type GoalsForDayResponseV1 struct {
+	goals []Goal
+}

--- a/server/models/api-responses.go
+++ b/server/models/api-responses.go
@@ -9,8 +9,8 @@ type HabitsSummaryResponseV1 struct {
 }
 
 type HabitsForDayResponseV1 struct {
-	Completed   []Goal `json:"completed"`
-	Uncompleted []Goal `json:"uncompleted"`
+	Completed   []GoalSummary `json:"completed"`
+	Uncompleted []GoalSummary `json:"uncompleted"`
 }
 
 type GoalsResponseV1 struct {

--- a/server/models/api-responses_test.go
+++ b/server/models/api-responses_test.go
@@ -1,0 +1,34 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHabitsSummaryResponseV1(t *testing.T) {
+	expectedJson := []byte(`{"habits":[{"date":"2023-08-26","completed":2,"uncompleted":3},{"date":"2023-08-25","completed":3,"uncompleted":3}]}`)
+
+	var response HabitsSummaryResponseV1
+	response.Habits = []HabitSummary{
+		{
+			Date:        "2023-08-26",
+			Completed:   2,
+			Uncompleted: 3,
+		},
+		{
+			Date:        "2023-08-25",
+			Completed:   3,
+			Uncompleted: 3,
+		},
+	}
+	json, err := json.Marshal(&response)
+	if err != nil {
+		t.Fatalf("Failed to write json")
+	}
+
+	expectedJsonString := string(expectedJson)
+	actualJsonString := string(json)
+	if expectedJsonString != actualJsonString {
+		t.Fatalf("Response did not match expected value:\n\texpected \"%v\"\n\tgot      \"%v\"", expectedJsonString, actualJsonString)
+	}
+}

--- a/server/models/data.go
+++ b/server/models/data.go
@@ -1,0 +1,16 @@
+package models
+
+type Identity struct {
+	userId string
+}
+
+type HabitSummary struct {
+	date        string
+	completed   int
+	uncompleted int
+}
+
+type Goal struct {
+	title  string
+	goalId string
+}

--- a/server/models/data.go
+++ b/server/models/data.go
@@ -1,16 +1,16 @@
 package models
 
 type Identity struct {
-	userId string
+	UserId string `json:"UserId"`
 }
 
 type HabitSummary struct {
-	date        string
-	completed   int
-	uncompleted int
+	Date        string `json:"date"`
+	Completed   int    `json:"completed"`
+	Uncompleted int    `json:"uncompleted"`
 }
 
 type Goal struct {
-	title  string
-	goalId string
+	Title  string `json:"title"`
+	GoalId string `json:"goalId"`
 }

--- a/server/models/data.go
+++ b/server/models/data.go
@@ -11,6 +11,26 @@ type HabitSummary struct {
 }
 
 type Goal struct {
-	Title  string `json:"title"`
+	Title    string     `json:"title"`
+	GoalId   string     `json:"goalId"`
+	IsActive DaysActive `json:"isActive"`
+}
+
+type GoalId struct {
 	GoalId string `json:"goalId"`
+}
+
+type GoalSummary struct {
+	GoalId string `json:"goalId"`
+	Title  string `json:"title"`
+}
+
+type DaysActive struct {
+	Monday    bool `json:"monday"`
+	Tuesday   bool `json:"tuesday"`
+	Wednesday bool `json:"wednesday"`
+	Thursday  bool `json:"thursday"`
+	Friday    bool `json:"friday"`
+	Saturday  bool `json:"saturday"`
+	Sunday    bool `json:"sunday"`
 }


### PR DESCRIPTION
This sets up the initial infrastructure for the backend service.

This includes getting an authentication layer setup in front of my Cloud Functions (auth layer is JWT's from Auth0), as well as stubs for the following endpoints (described in OpenAPI):
- GET whoami (for determining your userId based on your JWT)
- GET habits summary (for determining a summary of habit progress to show on the home screen)
- GET habits for day (for determining what habits you completed on a given day when looking at a detailed view)
- POST habits for day (for noting that you completed a habit)
- GET goals (for listing all your current goals)
- POST goals (for updating your goals)