### PR TITLE
Update /habits/summary to return list of completed/uncompleted goals

### DIFF
--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -32,7 +32,7 @@ paths:
             example: "Descriptive error message"
   /v1/{userId}/habits/summary:
     get:
-      summary: Gets how many habits the user has completed each day for up to the last 100 days.
+      summary: Gets how many habits the user has completed each day for some number of days.
       operationId: getHabitsSummaryV1
       parameters:
         - in: path
@@ -40,6 +40,16 @@ paths:
           required: true
           type: string
           description: The User ID of the user to lookup.
+        - in: query
+          name: startingFrom
+          required: false
+          type: string
+          description: The date to start looking up habit summaries and going backwards in time. Must be formatted as YYYY-MM-DD. Defaults to the current day.
+        - in: query
+          name: count
+          required: false
+          type: integer
+          description: The number of dates to lookup. No more than this number of summary results will be returned, although fewer may be returned. Defaults to 100.
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits-summary
         protocol: h2
@@ -229,9 +239,15 @@ definitions:
               type: string
               example: "YYYY-MM-DD"
             completed:
-              type: integer
+              type: array
+              items:
+                type: string
+                description: Goal ID of a goal completed on this day.
             uncompleted:
-              type: integer
+              type: array
+              items:
+                type: string
+                description: Goal ID of a goal not completed on this day.
   HabitsForDayResponseV1:
     type: object
     properties:
@@ -318,5 +334,3 @@ definitions:
             type: boolean
           sunday:
             type: boolean
-      
-      

--- a/server/api/openapi-functions.yaml
+++ b/server/api/openapi-functions.yaml
@@ -49,7 +49,7 @@ paths:
           name: count
           required: false
           type: integer
-          description: The number of dates to lookup. No more than this number of summary results will be returned, although fewer may be returned. Defaults to 100.
+          description: The number of dates to lookup. No more than this number of summary results will be returned, although fewer may be returned. Defaults to 100. Must be smaller than 366 and larger than 0.
       x-google-backend:
         address: https://us-west1-simon-duchastel-habit-tracker.cloudfunctions.net/v1-get-habits-summary
         protocol: h2

--- a/server/api/v1/habits-summary-get.go
+++ b/server/api/v1/habits-summary-get.go
@@ -19,23 +19,23 @@ func GetHabitsSummary(w http.ResponseWriter, r *http.Request) {
 	response.Habits = []models.HabitSummary{
 		{
 			Date:        "2023-08-26",
-			Completed:   2,
-			Uncompleted: 3,
+			Completed:   []string{"goal-1", "goal-2"},
+			Uncompleted: []string{"goal-3", "goal-4", "goal-5"},
 		},
 		{
 			Date:        "2023-08-25",
-			Completed:   3,
-			Uncompleted: 3,
+			Completed:   []string{"goal-1", "goal-3"},
+			Uncompleted: []string{"goal-2", "goal-4", "goal-5"},
 		},
 		{
-			Date:        "2023-08-25",
-			Completed:   3,
-			Uncompleted: 3,
+			Date:        "2023-08-24",
+			Completed:   []string{"goal-1", "goal-2", "goal-3"},
+			Uncompleted: []string{"goal-4", "goal-5"},
 		},
 		{
-			Date:        "2023-08-25",
-			Completed:   3,
-			Uncompleted: 3,
+			Date:        "2023-08-23",
+			Completed:   []string{"goal-1", "goal-2", "goal-3", "goal-4", "goal-5"},
+			Uncompleted: []string{},
 		},
 	}
 

--- a/server/models/api-responses_test.go
+++ b/server/models/api-responses_test.go
@@ -6,19 +6,19 @@ import (
 )
 
 func TestHabitsSummaryResponseV1(t *testing.T) {
-	expectedJson := []byte(`{"habits":[{"date":"2023-08-26","completed":2,"uncompleted":3},{"date":"2023-08-25","completed":3,"uncompleted":3}]}`)
+	expectedJson := []byte(`{"habits":[{"date":"2023-08-26","completed":["goal-1","goal-2"],"uncompleted":["goal-3","goal-4","goal-5"]},{"date":"2023-08-25","completed":["goal-1","goal-2","goal-3"],"uncompleted":["goal-4","goal-5","goal-6"]}]}`)
 
 	var response HabitsSummaryResponseV1
 	response.Habits = []HabitSummary{
 		{
 			Date:        "2023-08-26",
-			Completed:   2,
-			Uncompleted: 3,
+			Completed:   []string{"goal-1", "goal-2"},
+			Uncompleted: []string{"goal-3", "goal-4", "goal-5"},
 		},
 		{
 			Date:        "2023-08-25",
-			Completed:   3,
-			Uncompleted: 3,
+			Completed:   []string{"goal-1", "goal-2", "goal-3"},
+			Uncompleted: []string{"goal-4", "goal-5", "goal-6"},
 		},
 	}
 	json, err := json.Marshal(&response)

--- a/server/models/data.go
+++ b/server/models/data.go
@@ -5,9 +5,9 @@ type Identity struct {
 }
 
 type HabitSummary struct {
-	Date        string `json:"date"`
-	Completed   int    `json:"completed"`
-	Uncompleted int    `json:"uncompleted"`
+	Date        string   `json:"date"`
+	Completed   []string `json:"completed"`
+	Uncompleted []string `json:"uncompleted"`
 }
 
 type Goal struct {


### PR DESCRIPTION
This includes 3 changes:
- update the return type of /habits/summary to include a list of completed goal IDs and a list of uncompleted goal IDs instead of a count of each
- Update /habits/summary to take a query parameter specifying # of dates to look up (optional)
- Update /habits/summary to take a query parameter specifying # of dates to look up (optional)

## List of Goal IDs

As I was writing the android client app, I realized the summary API should know about which goals were completed and which ones weren't (rather than just receiving a count). This allows the consumers of the summary API to do intelligent work such as behave differently when a goal was missed twice in a row. 

For extensibility, in the future this could also permit clients to do look-ups on individual goals of interest without additional network calls.

## Query Param for Start Date
I realized that clients need a way to specify which date the API should start returning dates from. I chose to have this be an upper bound, ie. if you pass "2023-08-29" in the `startingFrom` field then you'll receive summary information for the dates "2023-08-29", "2023-08-28", "2023-08-27", etc.

## Query Param for # of Dates
I realized that it would be helpful to have a parameter specifying number of dates (if a client ever wants to specify more or less data received). Defaults to a reasonable number of responses (100).

Note that this is the maximum number of dates to return. The API does omits a date if there were no goals to complete on that date (ie. the date is not in the system because there's nothing to track). 